### PR TITLE
Add support for emptyLines option when parsing markdown

### DIFF
--- a/lib/configs/default.js
+++ b/lib/configs/default.js
@@ -22,7 +22,8 @@ export default {
     //
     highlight: null,
 
-    maxNesting:   20            // Internal protection, recursion limit
+    maxNesting:   20,           // Internal protection, recursion limit
+    emptyLines:   false         // Preserve empty lines with empty <p> tag
   },
 
   components: {
@@ -36,7 +37,8 @@ export default {
         'smartquotes',
         'references',
         'abbr2',
-        'footnote_tail'
+        'footnote_tail',
+        'empty_lines'
       ]
     },
 

--- a/lib/configs/full.js
+++ b/lib/configs/full.js
@@ -22,7 +22,8 @@ export default {
     //
     highlight:     null,
 
-    maxNesting:    20            // Internal protection, recursion limit
+    maxNesting:    20,           // Internal protection, recursion limit
+    emptyLines:    false         // Preserve empty lines with empty <p> tag
   },
 
   components: {

--- a/lib/parser_block.js
+++ b/lib/parser_block.js
@@ -65,7 +65,13 @@ ParserBlock.prototype.tokenize = function (state, startLine, endLine) {
   var ok, i;
 
   while (line < endLine) {
-    state.line = line = state.skipEmptyLines(line);
+    var newLine = state.skipEmptyLines(line);
+    // save the emtpy lines info into state.env.emptyLines
+    if (state.options.emptyLines === true && newLine > line) {
+      state.env.emptyLines = state.env.emptyLines || {};
+      state.env.emptyLines[line] = newLine - line;
+    }
+    state.line = line = newLine;
     if (line >= endLine) {
       break;
     }

--- a/lib/parser_core.js
+++ b/lib/parser_core.js
@@ -8,6 +8,7 @@ import footnote_tail from './rules_core/footnote_tail';
 import abbr2 from './rules_core/abbr2';
 import replacements from './rules_core/replacements';
 import smartquotes from './rules_core/smartquotes';
+import empty_lines from "./rules_core/empty_lines";
 
 /**
  * Core parser `rules`
@@ -22,6 +23,7 @@ var _rules = [
   [ 'abbr2',          abbr2          ],
   [ 'replacements',   replacements   ],
   [ 'smartquotes',    smartquotes    ],
+  [ 'empty_lines',    empty_lines    ],
 ];
 
 /**

--- a/lib/rules_core/empty_lines.js
+++ b/lib/rules_core/empty_lines.js
@@ -1,0 +1,60 @@
+// Transform empty lines into empty <p> tags
+// empty lines data comes from state.env.emptyLines,
+
+export default function empty_lines_block(state) {
+    var i, ln;
+    var emptyLines = state.env.emptyLines;
+    if (!emptyLines || state.options.emptyLines !== true) {
+      return;
+    }
+    var tokens = state.tokens;
+    var pendingTokens = [];
+    var lastVisitedIndex = 0;
+    for (var lineNumber in emptyLines) {
+      for (i = lastVisitedIndex; i < tokens.length; i++) {
+        var token = tokens[i];
+        ln = Number(lineNumber);
+        // find the first "paragraph" that after the current empty lines
+        if (
+          token.type === 'paragraph_open' &&
+          token.lines &&
+          token.lines[0] >= ln
+        ) {
+          // push the index info of the found "paragraph"
+          pendingTokens.push({
+            index: i,
+            lineNumber: ln,
+            level: token.level
+          });
+          lastVisitedIndex = ln;
+          break;
+        }
+      }
+    }
+  
+    // insert the empty line from last to first
+    while (pendingTokens.length > 0) {
+      var t = pendingTokens.pop();
+      var idx = t.index, lvl = t.level;
+      ln = t.lineNumber;
+      for (i = 0; i < emptyLines[ln] - 1; i++) {
+        tokens.splice(
+          idx,
+          0,
+          {
+            type: 'paragraph_open',
+            tight: false,
+            lines: [ln + i, ln + i + emptyLines[ln]],
+            level: lvl
+          },
+          {
+            type: 'paragraph_close',
+            tight: false,
+            level: lvl
+          }
+        );
+      }
+    }
+  
+    state.tokens = tokens;
+  };

--- a/test/empty_lines.test.js
+++ b/test/empty_lines.test.js
@@ -1,0 +1,36 @@
+
+import assert from 'assert';
+import { Remarkable } from '../lib/index';
+
+describe('Test empty lines plugin', function() {
+  it('should render with empty lines when enabled', function() {
+    [
+      ['', ''],
+      ['abc\n\ndef\n', '<p>abc</p>\n<p>def</p>\n'],
+      ['abc\n\n\ndef\n', '<p>abc</p>\n<p>def</p>\n'],
+      ['abc\n\n\n\ndef\n\n\n\nghi\n', '<p>abc</p>\n<p></p>\n<p>def</p>\n<p></p>\n<p>ghi</p>\n'],
+      ['line1\n\n\n\nline3\n', '<p>line1</p>\n<p></p>\n<p>line3</p>\n'],
+      ['* line1\n* line2\n\n\nline4\n', '<ul>\n<li>line1</li>\n<li>line2</li>\n</ul>\n<p>line4</p>\n']
+    ].forEach(function(data) {
+      var [text, expected] = data;
+      var md = new Remarkable('full', { emptyLines: true });
+      var rendered = md.render(text);
+      assert.strictEqual(rendered, expected);
+    });
+  });
+
+  it('should render without empty lines when disabled', function() {
+    [
+      ['', ''],
+      ['abc\n\ndef\n', '<p>abc</p>\n<p>def</p>\n'],
+      ['abc\n\n\ndef\n', '<p>abc</p>\n<p>def</p>\n'],
+      ['line1\n\n\n\nline3\n', '<p>line1</p>\n<p>line3</p>\n'],
+      ['* line1\n* line2\n\n\n\n\n\n\nline4\n', '<ul>\n<li>line1</li>\n<li>line2</li>\n</ul>\n<p>line4</p>\n']
+    ].forEach(function(data) {
+      var [text, expected] = data;
+      var md = new Remarkable('full');
+      var rendered = md.render(text);
+      assert.strictEqual(rendered, expected);
+    });
+  });
+});


### PR DESCRIPTION
Use code from: https://github.com/jonschlinkert/remarkable/pull/396

To fix the issue of markdown automatically omit multiple new lines

Detail of this issue can be found at: https://github.com/jonschlinkert/remarkable/issues/242